### PR TITLE
Hardening the authentication

### DIFF
--- a/admin/inc/auth.inc.php
+++ b/admin/inc/auth.inc.php
@@ -1,8 +1,9 @@
 <?php
 
 include dirname(__FILE__).'/pwd.inc.php';
+require_once __DIR__.'/../../app/classes/Planet.class.php';
 
-if (!isset($_COOKIE['auth']) || $_COOKIE['auth'] !== $password) {
+if (!Planet::authenticateUser($_COOKIE['auth'], $password)) {
     setcookie('auth', '', time() - 3600);
     header('Location: login.php');
     die();

--- a/admin/inc/auth.inc.php
+++ b/admin/inc/auth.inc.php
@@ -1,7 +1,7 @@
 <?php
 include (dirname(__FILE__).'/pwd.inc.php');
 
-if ( isset($_COOKIE['auth']) && $_COOKIE['auth'] == $password ) {
+if ( isset($_COOKIE['auth']) && $_COOKIE['auth'] === $password ) {
     //ok, cool
 } else {
     setcookie('auth','', time()-3600);

--- a/admin/inc/auth.inc.php
+++ b/admin/inc/auth.inc.php
@@ -1,11 +1,9 @@
 <?php
-include (dirname(__FILE__).'/pwd.inc.php');
 
-if ( isset($_COOKIE['auth']) && $_COOKIE['auth'] === $password ) {
-    //ok, cool
-} else {
-    setcookie('auth','', time()-3600);
+include dirname(__FILE__).'/pwd.inc.php';
+
+if (!isset($_COOKIE['auth']) || $_COOKIE['auth'] !== $password) {
+    setcookie('auth', '', time() - 3600);
     header('Location: login.php');
-    die;
+    die();
 }
-?>


### PR DESCRIPTION
Password comparison should not be done with the `==` operator, but `===`, due to type juggling.

### References

* http://phpsadness.com/sad/47
* turbochaos.blogspot.fr/2013/08/exploiting-exotic-bugs-php-type-juggling.html

### Test case

* Create an administrator with the password "240610708".
* Try to login to the dashboard with the password "QNKCDZO" :-)