### PR TITLE
Fix short echo open tags deprecation

### DIFF
--- a/custom/views/archive/footer.tpl.php
+++ b/custom/views/archive/footer.tpl.php
@@ -1,3 +1,3 @@
         <div id="footer">
-            <p><? echo str_replace('%s', 'href="http://moonmoon.org"', _g('Powered by <a %s>moonmoon</a>'))?> | <a href="./admin/"><?=_g('Administration')?></a></p>
+            <p><?php echo str_replace('%s', 'href="http://moonmoon.org"', _g('Powered by <a %s>moonmoon</a>'))?> | <a href="./admin/"><?=_g('Administration')?></a></p>
         </div>

--- a/custom/views/default/footer.tpl.php
+++ b/custom/views/default/footer.tpl.php
@@ -1,3 +1,3 @@
         <div id="footer">
-            <p><? echo str_replace('%s', 'href="http://moonmoon.org"', _g('Powered by <a %s>moonmoon</a>'))?> | <a href="./admin/"><?=_g('Administration')?></a></p>
+            <p><?php echo str_replace('%s', 'href="http://moonmoon.org"', _g('Powered by <a %s>moonmoon</a>'))?> | <a href="./admin/"><?=_g('Administration')?></a></p>
         </div>


### PR DESCRIPTION
Short echo open tags are deprecated and disabled by default in php.ini
since PHP 5.5.0. It does not break anything for olders versions.